### PR TITLE
Fix crash on GC trigger

### DIFF
--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/amd64.S
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/amd64.S
@@ -446,12 +446,36 @@ CFI_STARTPROC
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc3))
 
-/* TODO:Isfarul change this caml_allocN */
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
+    /* Save OCaml stack context so caml_do_local_roots_nat can scan roots.
+       The code generator (emit.vergc.diff) builds this stack layout before
+       calling us:
+         rsp+0:   return address into OCaml compiled code  <- last_return_address
+                  (has a frame descriptor: record_frame_label emits one here)
+         rsp+8:   xmm0..xmm15 save area (16 * 8 = 128 bytes)
+         rsp+136: saved rax  \
+         rsp+144: saved rbx   |
+         rsp+152: saved rdi   |
+         rsp+160: saved rsi   | GP register save array (13 regs, 104 bytes)
+         rsp+168: saved rdx   | layout matches caml_call_gc, so gc_regs
+         rsp+176: saved rcx   | indexing in caml_do_local_roots_nat is correct
+         rsp+184: saved r8    |
+         rsp+192: saved r9    |
+         rsp+200: saved r12   |
+         rsp+208: saved r13   |
+         rsp+216: saved r10   |
+         rsp+224: saved r11   |
+         rsp+232: saved rbp  /
+         rsp+240: OCaml sp before the save sequence  <- bottom_of_stack
+    */
+        movq    (%rsp), %r11
+        movq    %r11, Caml_state(last_return_address)   /* retaddr into OCaml code */
+        leaq    240(%rsp), %r11
+        movq    %r11, Caml_state(bottom_of_stack)        /* OCaml sp before saves  */
+        leaq    136(%rsp), %r11
+        movq    %r11, Caml_state(gc_regs)                /* base of GP save array  */
         call    GCALL(verified_bhallocate)
-        /* cmpq    Caml_state(young_limit), %r15 */
-        /* jb      LBL(caml_call_gc) */
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/amd64.S
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/amd64.S
@@ -410,42 +410,6 @@ LBL(caml_call_gc):
 CFI_ENDPROC
 ENDFUNCTION(G(caml_call_gc))
 
-/* TODO:Isfarul change this caml_alloc1 */
-FUNCTION(G(caml_alloc1))
-CFI_STARTPROC
-        mov     $16, %rdi
-        call    GCALL(verified_bhallocate)
-        /* subq    $16, %r15 */
-        /* cmpq    Caml_state(young_limit), %r15 */
-        /* jb      LBL(caml_call_gc) */
-        ret
-CFI_ENDPROC
-ENDFUNCTION(G(caml_alloc1))
-
-/* TODO:Isfarul change this caml_alloc2 */
-FUNCTION(G(caml_alloc2))
-CFI_STARTPROC
-        mov     $24, %rdi
-        call    GCALL(verified_bhallocate)
-        /* subq    $24, %r15 */
-        /* cmpq    Caml_state(young_limit), %r15 */
-        /* jb      LBL(caml_call_gc) */
-        ret
-CFI_ENDPROC
-ENDFUNCTION(G(caml_alloc2))
-
-/* TODO:Isfarul change this caml_alloc3 */
-FUNCTION(G(caml_alloc3))
-CFI_STARTPROC
-        mov     $32, %rdi
-        call    GCALL(verified_bhallocate)
-        /* subq    $32, %r15 */
-        /* cmpq    Caml_state(young_limit), %r15 */
-        /* jb      LBL(caml_call_gc) */
-        ret
-CFI_ENDPROC
-ENDFUNCTION(G(caml_alloc3))
-
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
     /* Save OCaml stack context so caml_do_local_roots_nat can scan roots.

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/Impl_GC_closure_infix_ver3.c
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/Impl_GC_closure_infix_ver3.c
@@ -218,10 +218,6 @@ void Impl_GC_closure_infix_ver3_sweep_body_helper_with_free_list1(
   uint64_t h_index = Spec_GC_infix_closure_ver3_hd_address(f_index_val);
   uint64_t c = Impl_GC_closure_infix_ver3_color_of_block(h_index, g);
   uint64_t wz = Impl_GC_closure_infix_ver3_wosize_of_block(h_index, g);
-  // Handwritten, to handle 0 sized blocks
-  if (wz == 0) {
-    return;
-  }
 
   if (c == Spec_GC_infix_closure_ver3_white ||
       c == Spec_GC_infix_closure_ver3_blue) {

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/allocator.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/allocator.rs
@@ -111,80 +111,58 @@ impl NfAllocator {
             (prev == self.get_globals().nf_head && cur == *get_next(&prev)) || (prev.0 < cur.0),
             "[nf_allocate_block] prev<cur invariant broken"
         );
+        let wosize = cur.get_header().get_wosize();
+        let wo_sz = wosize_whsize(wh_sz);
         assert!(
-            whsize_wosize(cur.get_header().get_wosize()) >= wh_sz,
-            "The invariant(block size should be enough) to be maintained is broken. to_be_allocated block doesnt have enough size to satisfy the request."
+            wosize == wo_sz || wosize >= wh_sz + Wsize::new(1),
+            "Block must be exact-fit (wosize == wo_sz) or splittable (wosize >= wh_sz+1). \
+             Near-fit (wosize == wh_sz) is forbidden: it creates a tombstone."
         );
     }
 
     fn nf_allocate_block(&mut self, prev: Value, cur: Value, wh_sz: Wsize) -> *mut Header {
-        let hd_sz = cur.get_header().get_wosize();
+        let curr_wo_sz = cur.get_header().get_wosize();
+        let wo_sz = wosize_whsize(wh_sz);
 
         #[cfg(feature = "check_invariants")]
         self.check_nf_allocate_block_invariant(prev, cur, wh_sz);
 
-        if *cur.get_header().get_wosize().get_val() < (wh_sz.get_val() + 1) {
-            // If we're here, the size of header is exactly wh_sz or wo_sz[=wosize_whsize(wh_sz)]
-            // This is only ever called from nf_allocate, we will never be breaking this invariant.
-            // So the size of header can only be these two values
-            //
-            // # equals wo_sz
-            //
-            // We'll change the header to size zero inside this branch. But later on before
-            // returning,it's changed back to wo_sz(the requested size)
-            //
-            // # equals to wh_sz
-            //
-            // We'll change the header to have size 0 in this branch. The next header right after
-            // it is what we must return. IMP: this must be handled while merging. Any value that
-            // we get, it might be succeeding an empty block header,so that check must be made.
-            //
-            //
-            // The reason we're setting the header here is so that we can actually merge it later.
-            // If we dont keep track of this header's 0 size, we wont know it's useless later on
-            // and it will forever create a gap which wont be merged.
-            //
+        // Near-fit (wosize == wh_sz) is forbidden: find_next never returns such blocks.
+        debug_assert!(
+            curr_wo_sz != wh_sz,
+            "tombstone-creating case (wosize == wh_sz) must not reach nf_allocate_block"
+        );
 
-            self.get_globals_mut().cur_wsz -= whsize_wosize(cur.get_header().get_wosize());
+        if curr_wo_sz == wo_sz {
+            // Case A: exact fit — consume the whole block.
+            // offset = wo_sz - wh_sz = -1, so the new block's header is written at
+            // cur-8 (the old free block's header slot) by the common code below.
+            // Unlink cur from the free list entirely.
+            self.get_globals_mut().cur_wsz -= whsize_wosize(curr_wo_sz);
             *get_next(&prev) = *get_next(&cur);
-
-            cur.get_header().set_wosize(Wsize::new(0));
-            cur.get_header().set_color(WHITE); // This will be overwritten if it
-                                               // was given wrong header, else
-                                               // this'll be the empty block(which
-                                               // is rightly always
-                                               // unreachable(WHITE))
-
-            // If the pointer we returned was nf_last, we change nf_last
-            // This way we're always keeping track of nf_last properly
             if cur == self.get_globals().nf_last {
                 self.get_globals_mut().nf_last = prev;
                 *get_next(&self.get_globals().nf_last) = VAL_NULL;
             }
         } else {
+            // Case B: normal split (curr_wo_sz >= wh_sz + 1).
+            // Shrink the free block header by wh_sz words; remaining wosize >= 1.
             self.get_globals_mut().cur_wsz -= wh_sz;
             *cur.get_header() = Header::new(
-                cur.get_header().get_wosize().get_val() - wh_sz.get_val(),
+                *curr_wo_sz.get_val() - *wh_sz.get_val(),
                 BLUE,
                 DEFAULT_TAG,
             );
         }
 
-        // since we always split and return the right half,we must calculate the offset at which we split.
-        //
-        // case wo_sz == hd_sz => -1, this causes the cur.get_header() to have right size
-        //
-        // case wh_sz == hd_sz => 0, empty block is already there, it'll put header for block to be
-        // returned properly
-        //
-        // case hd_sz >= wh_sz + 1 => positive value, the split block will have proper header
-        let offset = *hd_sz.get_val() as isize - *wh_sz.get_val() as isize;
+        // Carve from the right half of the (possibly shrunk) free block.
+        // Case A: offset = -1  -> new block header lands at cur-8 (old free header)
+        // Case B: offset >= 1  -> new block header lands at cur + offset*8 (right half)
+        let offset = *curr_wo_sz.get_val() as isize - *wh_sz.get_val() as isize;
 
-        // Set the header for the memory that we'll be returning, IMP: Make it have WHITE color,
-        // if it's reachable, it'll be made white by the  sweep
+        // Write the header of the new allocated block and mark it WHITE (live).
         let val = field_val(cur, offset + 1);
-        val.get_header()
-            .set_wosize(Wsize::new(*wosize_whsize(wh_sz).get_val()));
+        val.get_header().set_wosize(wo_sz);   // wo_sz already computed above
         val.get_header().set_color(WHITE);
 
         self.get_globals_mut().nf_prev = prev;

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/allocator.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/allocator.rs
@@ -74,7 +74,7 @@ impl NfAllocator {
         }
     }
 
-    pub fn get_pool_iter(&self) -> PoolIter {
+    pub fn get_pool_iter(&self) -> PoolIter<'_> {
         // at all times pool_head will point to valid pool(the global one with static lifetime or
         // the one gotten through Box::leak)
         PoolIter::new(&self.get_globals().pool_head)

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/fl.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/fl.rs
@@ -28,7 +28,16 @@ impl FreeList<'_> {
 
     pub fn find_next(&mut self, wo_sz: Wsize) -> Option<NfIterVal> {
         self.nf_iter()
-            .find(|e| e.get_cur().get_header().get_wosize().get_val() >= wo_sz.get_val())
+            .find(|e| {
+                let wosize = e.get_cur().get_header().get_wosize();
+                // Allow exact fit (wosize == wo_sz): whole block consumed, offset = -1
+                //   overwrites the free header with the new block header — no tombstone.
+                // Allow normal split (wosize >= wo_sz + 2): remaining
+                //   fragment has >= 1 payload word — valid free block.
+                // Disallow near-fit (wosize == wo_sz + 1): would leave a 1-word
+                //   fragment (header only, no payload) — tombstone, violates heap invariant.
+                wosize == wo_sz || wosize >= wo_sz + Wsize::new(2)
+            })
     }
 }
 

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/fl.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/fl.rs
@@ -1,5 +1,4 @@
 use crate::{
-    colors::BLUE,
     utils::get_next,
     value::{Value, VAL_NULL},
     word::Wsize,
@@ -22,7 +21,7 @@ impl FreeList<'_> {
             visited_start_once: false,
         }
     }
-    pub fn new(g: &mut NfGlobals) -> FreeList {
+    pub fn new(g: &mut NfGlobals) -> FreeList<'_> {
         FreeList { globals: g }
     }
 

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/mod.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/freelist/mod.rs
@@ -95,18 +95,28 @@ mod tests {
                 acc + x.get_cur().get_header().get_wosize()
             });
 
-        //The following allocation will force the empty block case in nf_allocate_block
-        let hp = allocator.nf_allocate(allocatable_memory_left - Wsize::new(1));
+        // Near-fit (wo_sz = allocatable_memory_left - 1) would leave a 1-word fragment
+        // (header only, no payload) — a tombstone. find_next now skips such blocks,
+        // so this must return null.
+        let rejected = allocator.nf_allocate(allocatable_memory_left - Wsize::new(1));
+        assert_eq!(
+            rejected,
+            std::ptr::null_mut(),
+            "near-fit allocation must be rejected to prevent tombstone creation"
+        );
+        // Free list must be unchanged after the rejected allocation.
+        assert_eq!(
+            FreeList::new(allocator.get_globals_mut()).nf_iter().count(),
+            1
+        );
 
+        // Exact-fit (wo_sz = allocatable_memory_left) consumes the whole block (Case A).
+        // The new block header lands at the old free block's header slot — no tombstone.
+        let hp = allocator.nf_allocate(allocatable_memory_left);
+        assert_ne!(hp, std::ptr::null_mut());
         assert_eq!(
             val_hp!(hp).get_header().get_wosize(),
-            allocatable_memory_left - Wsize::new(1)
-        );
-        //Assert the size of empty block that lies 1 word before hp
-        assert_eq!(
-            Value(hp as usize).get_header().get_wosize(), // treat hp as val, it'll treat empty
-            // block as it's header
-            Wsize::new(0)
+            allocatable_memory_left
         );
         allocations.push(Some(hp));
 

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/utils.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/utils.rs
@@ -1,6 +1,6 @@
 use std::{alloc::Layout, env};
 
-use crate::{colors::BLUE, freelist::pool::Pool, header::Header, value::Value, word::Wsize};
+use crate::{colors::BLUE, freelist::pool::Pool, value::Value, word::Wsize};
 
 #[cfg(target_pointer_width = "16")]
 static ALIGN: usize = 2usize;

--- a/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/value.rs
+++ b/ExtractedCodeIntegratedWithRuntime/ocaml-4.14-verified-gc/runtime/verified_gc/allocator/src/value.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use std::fmt::{self, Debug};
 
 use crate::{
     bp_val,

--- a/ExtractedCodeIntegratedWithRuntime/tests/gc_probe.ml
+++ b/ExtractedCodeIntegratedWithRuntime/tests/gc_probe.ml
@@ -1,0 +1,23 @@
+let rec tail lst = match lst with
+  | [] -> None | [t] -> Some t | _ :: t -> tail t
+
+let churn n =
+  let acc = ref [] in
+  for i = 0 to n do
+    acc := [i;i+1] :: !acc;
+    if i mod 1000 = 0 then acc := []
+  done; List.length !acc
+
+let () =
+  let live = tail [1;2;3] in   (* Some 3 *)
+  Printf.printf "BEFORE churn: live = Some %d? %b\n"
+    (match live with Some x -> x | None -> -1)
+    (live = Some 3);
+  (* Churn just enough to fill the heap. 
+     14541 is just below the full heap size, 
+     as each churn cycles allocates 9 bytes on heap *)
+  let _ = churn 14_542 in
+  (match live with
+   | Some x -> Printf.printf "AFTER churn: live = Some %d\n" x
+   | None   -> Printf.printf "AFTER churn: live = None (CORRUPTED!)\n");
+  Printf.printf "AFTER churn: (live = Some 3) = %b\n" (live = Some 3)

--- a/ExtractedCodeIntegratedWithRuntime/vergc_opt/gc_probe.ml
+++ b/ExtractedCodeIntegratedWithRuntime/vergc_opt/gc_probe.ml
@@ -1,0 +1,23 @@
+let rec tail lst = match lst with
+  | [] -> None | [t] -> Some t | _ :: t -> tail t
+
+let churn n =
+  let acc = ref [] in
+  for i = 0 to n do
+    acc := [i;i+1] :: !acc;
+    if i mod 1000 = 0 then acc := []
+  done; List.length !acc
+
+let () =
+  let live = tail [1;2;3] in   (* Some 3 *)
+  Printf.printf "BEFORE churn: live = Some %d? %b\n"
+    (match live with Some x -> x | None -> -1)
+    (live = Some 3);
+  (* Churn just enough to fill the heap. 
+     14541 is just below the full heap size, 
+     as each churn cycles allocates 9 bytes on heap *)
+  let _ = churn 14_542 in
+  (match live with
+   | Some x -> Printf.printf "AFTER churn: live = Some %d\n" x
+   | None   -> Printf.printf "AFTER churn: live = None (CORRUPTED!)\n");
+  Printf.printf "AFTER churn: (live = Some 3) = %b\n" (live = Some 3)


### PR DESCRIPTION
This PR fixes #4. A new test is added which fills the heap so that a GC pass is triggered.
The segfault happened within `caml_do_local_roots_nat()` in runtime/roots_nat.c
The root cause was a stale `caml_state` which led to an invalid key being accessed in the `caml_frame_descriptors`. This is due to `caml_allocN` not maintaining the current valid `caml_state` - which this PR fixes.
The `last_return_address` saved in the `caml_state` turned out to be an address in the .data section instead of the .text section, which led to seeing what poisons the state.
The amd64.S fix is written by Claude Sonnet 4.6, which was used as a pair debug buddy as well. Some dead code is removed from runtime/amd64.S too. 
